### PR TITLE
Add Static Class Variable LastReplaceCount

### DIFF
--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -3697,6 +3697,14 @@ struct select{
         PCRE2_SIZE error_offset;
 
     public: 
+        /// static class variable, get & set number of substitutions in most recent substitute regex
+        static int LastReplaceCount;
+        static int getLastReplaceCount() {
+            return LastReplaceCount;
+        }
+        static void setLastReplaceCount(int NewReplaceCount) {
+            LastReplaceCount = NewReplaceCount;
+        }
 
         /// Default Constructor.
         /// Initializes all class variables to defaults.
@@ -4370,7 +4378,7 @@ struct select{
             return initReplace().setSubject(mains).setReplaceWith(repl).setModifier(mod).replace(); 
         } 
     };
-    
+
     private:
     //prevent object instantiation of select class
     select();
@@ -4381,6 +4389,12 @@ struct select{
     ~select();
 };//struct select
 }//jpcre2 namespace
+
+// static class variable, initialize number of substitutions in most recent substitute regex
+template<> int jpcre2::select<char, (unsigned char)8>::Regex::LastReplaceCount = 0;
+template<> int jpcre2::select<char16_t, (unsigned char)16>::Regex::LastReplaceCount = 0;
+template<> int jpcre2::select<char32_t, (unsigned char)32>::Regex::LastReplaceCount = 0;
+template<> int jpcre2::select<wchar_t, (unsigned char)32>::Regex::LastReplaceCount = 0;
 
 
 inline void jpcre2::ModifierTable::parseModifierTable(std::string& tabjs, VecOpt& tabjv,
@@ -4545,6 +4559,10 @@ typename jpcre2::select<Char_T, BS>::String jpcre2::select<Char_T, BS>::MatchEva
                     return RegexMatch::getSubject();
                 }
             }
+
+            // static class variable, update number of substitutions in most recent substitute regex
+            Regex::setLastReplaceCount(ret);
+
             //If everything's ok exit the loop
             break;
         }
@@ -4663,6 +4681,10 @@ typename jpcre2::select<Char_T, BS>::String jpcre2::select<Char_T, BS>::RegexRep
                 return *r_subject_ptr;
             }
         }
+
+        // static class variable, update number of substitutions in most recent substitute regex
+        Regex::setLastReplaceCount(ret);
+
         //If everything's ok exit the loop
         break;
     }

--- a/src/test0.cpp
+++ b/src/test0.cpp
@@ -10,17 +10,17 @@
 typedef jpcre2::select<char> jpc;
 typedef jpcre2::select<wchar_t> jpw;
 
-   
+
 int main(){
     jpc::Regex   rec;
     jpw::Regex  rew;
-    
+
     rec.setPattern("\\d+").compile();
     rew.setPattern(L"\\d+").compile();
 
     jpw::VecNum vec_num32;
     jpcre2::VecOff vec_eoff;
-    
+
     jpw::RegexMatch rmw;
     size_t count =
     rmw.setRegexObject(&rew)
@@ -29,7 +29,7 @@ int main(){
        .setNumberedSubstringVector(&vec_num32)
        .setMatchEndOffsetVector(&vec_eoff)
        .match();
-    
+
     std::cout<<"\nMatch count: "<<count;
     std::wcout<<"\nFirst match: "<<vec_num32[0][0];
     std::cout<<"\nMatch ended at offset: "<<vec_eoff[vec_eoff.size()-1];
@@ -39,39 +39,51 @@ int main(){
 
     jpc::RegexMatch rm;
     jpc::RegexReplace rr;
-    
+
     rm.setRegexObject(&rec);
     rr.setRegexObject(&rec);
-    
+
 
     jpc::VecNum vec_num8;
     rm.setSubject("I am a subject with digits 3343242 4433243 443244")
       .setModifier("g")
       .setNumberedSubstringVector(&vec_num8)
       .match();
-     
+
     std::cout<<"\nFirst match: " + vec_num8[0][0];
-    
+
     jpc::Regex rec_2("[\\S]+");
     rm.setRegexObject(&rec_2)
       .setSubject("I am subject")
       .setNumberedSubstringVector(&vec_num8)
       .match();
     std::cout<<"\nFirst match: " + vec_num8[0][0];
-    
+
+    int lrc = jpc::Regex::getLastReplaceCount();
+    if(lrc != 0) { std::cerr << "\n" << "jpc::Regex::LastReplaceCount should be 0 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jpc::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
     std::cout<<"\nReplace: " + 
             rr.setSubject("I am a subject with digits 3343242 4433243 443244")
               .setReplaceWith("@")
               .setModifier("g")
               .replace();
-    
-    
+
+    lrc = jpc::Regex::getLastReplaceCount();
+    if(lrc != 3) { std::cerr << "\n" << "jpc::Regex::LastReplaceCount should be 3 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jpc::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
+
     std::cout<<"\nReplace2: " + 
             rr.setSubject("I am a subject with digits 3343242 4433243 443244")
               .setReplaceWith("@")
               .setModifier("g")
               .setRegexObject(&rec_2)
               .replace();
-   
-   return 0;
-   }
+
+    lrc = jpc::Regex::getLastReplaceCount();
+    if(lrc != 9) { std::cerr << "\n" << "jpc::Regex::LastReplaceCount should be 9 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jpc::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
+    return 0;
+}

--- a/src/test_replace.cpp
+++ b/src/test_replace.cpp
@@ -11,7 +11,11 @@ typedef jpcre2::select<char> jp;
 
 
 int main(){
-    jp::Regex re; 
+    jp::Regex re;
+
+    int lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 0) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 0 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
 
     //Compile the pattern
     re.setPattern("(?:(?<word>[?.#@:]+)|(?<word>\\w+))\\s*(?<digit>\\d+)")     //Set various parameters
@@ -36,6 +40,10 @@ int main(){
     
     if(rr.getErrorNumber() != 0)
         std::cerr<<"\n"<<rr.getErrorMessage();
-    
+
+    lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 1) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 1 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
 	return 0;
 }

--- a/src/test_shorts.cpp
+++ b/src/test_shorts.cpp
@@ -147,23 +147,44 @@ int main(){
      * A call to RegexReplace::replace() in the method chain will return the resultant string
      */
 
+    int lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 0) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 0 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
     std::cout<<"\n"<<
     //replace first occurrence of a digit with @
     jp::Regex("\\d").replace("I am the subject string 44", "@");
+
+    lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 1) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 1 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
 
     std::cout<<"\n"<<
     //replace all occurrences of a digit with @
     jp::Regex("\\d").replace("I am the subject string 44", "@", "g");
 
+    lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 2) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 2 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
     //swap two parts of a string
     std::cout<<"\n"<<
     jp::Regex("^([^\t]+)\t([^\t]+)$")
         .replace("I am the subject\tTo be swapped according to tab", "$2 $1");
+
+    lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 1) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 1 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
         
     //Doing the above with method chain:
     re.compile("^([^\t]+)\t([^\t]+)$");
     jp::RegexReplace(&re).setSubject("I am the subject\tTo be swapped according to tab")
                          .setReplaceWith("$2 $1")
                          .replace();
+
+    lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 1) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 1 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
+
     return 0;
 }

--- a/src/testme.cpp
+++ b/src/testme.cpp
@@ -132,13 +132,12 @@ int main(){
     //populates all vectors. It erases the matched part/s from the subject string.
     std::cout<<"\n\n### default callback: \n"<<cme.setCallback(jp::callback::eraseFill).nreplace();
     //After populating all vectors, you can use any type of callback without performing the match again.
-    
-    
+
     //The following (uncomment if you wanna test) will give you assertion failure, because the callback1 only populates NumSub vector,
     //but callback2 requires pre-exisiting (due to the 'false' argument to nreplace()) MapNas data:
     cme.reset().setSubject(&s3).setRegexObject(&re).setFindAll().setCallback(callback1).nreplace();
     //~ std::cout<<"\n\n### callback2: \n"<<cme.setCallback(callback2).nreplace(false); //Assertion failure.
-    
+
 
 
 
@@ -155,6 +154,10 @@ int main(){
     //Short note: 
     // * replace() funtion is for PCRE2 compatible substitute.
     // * nreplace() is JPCRE2 native replace function.
+
+    int lrc = jp::Regex::getLastReplaceCount();
+    if(lrc != 1) { std::cerr << "\n" << "jp::Regex::LastReplaceCount should be 1 but instead is " << lrc << "\n"; }
+    else { std::cout << "\n" << "jp::Regex::LastReplaceCount correctly found to be " << lrc << "\n"; }
     
     std::cout<<"\ncallback7: \n"<<cme.setCallback(callback7).setFindAll(false).replace();
     


### PR DESCRIPTION
@neurobin 
Per your request, I have added the LastReplaceCount static class variable, along with the getLastReplaceCount() and setLastReplaceCount() methods.  I am able to use this as a workaround to achieve Perl compatibility without the need for implementing a preplace() method.
I have also updated some of the JPCRE2 tests to include checking of the LastReplaceCount number.