### PR TITLE
Feature/config include

### DIFF
--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -61,10 +61,12 @@
 //previous inclusion of pcre2.h will be respected and we won't try to include it twice.
 //Thus one can pre-include pcre2.h from an arbitrary/non-standard path.
 #ifndef PCRE2_MAJOR
+extern "C" {
     #ifdef PCRE2_HAS_CONFIG
     #include <config.h> // pcre2 config
     #endif
     #include <pcre2.h>  // pcre2 header
+}
 #endif
 #include <string>       // std::string, std::wstring
 #include <vector>       // std::vector

--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -61,6 +61,9 @@
 //previous inclusion of pcre2.h will be respected and we won't try to include it twice.
 //Thus one can pre-include pcre2.h from an arbitrary/non-standard path.
 #ifndef PCRE2_MAJOR
+    #ifdef PCRE2_HAS_CONFIG
+    #include <config.h> // pcre2 config
+    #endif
     #include <pcre2.h>  // pcre2 header
 #endif
 #include <string>       // std::string, std::wstring


### PR DESCRIPTION
С headers must be included as C to avoid any linkage issues. Also I had issues with missed config file which is generated by CMake and contains important defines such as `PCRE2_STATIC` `SUPPORT_UNICODE` and `SUPPORT_JIT`