### PR TITLE
Add method Regex::getNumCaptures()

### DIFF
--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -3895,6 +3895,15 @@ struct select{
             return pat_str_ptr;
         }
 
+        ///Get number of captures from compiled code.
+        ///@return New line option value or 0.
+        Uint getNumCaptures() {
+            if(!code) return 0;
+            Uint numCaptures = 0;
+            int ret = Pcre2Func<sizeof( Char_T ) * CHAR_BIT>::pattern_info(code, PCRE2_INFO_CAPTURECOUNT, &numCaptures);
+            if(ret < 0) error_number = ret;
+            return numCaptures;
+        }
 
         /// Calculate modifier string from PCRE2 and JPCRE2 options and return it.
         ///

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -86,6 +86,7 @@ int main(){
     re.getErrorOffset(); \
     re.getPattern(); \
     re.getPatternPointer(); \
+    re.getNumCaptures(); \
     re.getPcre2Option(); \
     re.getJpcre2Option(); \
     re.getModifier(); \


### PR DESCRIPTION
This returns the actual number of captures in the pattern.

This is useful for APIs that pass captures as variadic arguments to a
callback: PCRE2 only returns captures up to the last one that matches, so if
some at the end do not match, the number of captures passed can vary.

This can confuse the callee, which would typically be expecting one argument
per capture.

The particular reason I made this change was for the Node binding of PCRE2,
which copies the JavaScript API String.prototype.replace(). Callback
functions for this API have the following signature:

f(match, capture1, ..., capturen, offset, string, named_groups)

It’s bad enough trying to deal with a variable number of capture arguments
in JavaScript; it’s even worse in TypeScript!