### PR TITLE
fix warnings that visual studio raises

### DIFF
--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -202,7 +202,7 @@ static inline std::string _tostdstring(size_t x){
 
 #ifndef JPCRE2_USE_MINIMUM_CXX_11
     char buf[128];
-    int written = std::sprintf(buf, "%u", x);
+    int written = std::sprintf(buf, "%ull", (unsigned long long)x);
     return (written > 0) ? std::string(buf, buf + written) : std::string();
 #else
     return std::to_string(x);

--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -198,10 +198,15 @@ static inline void _jvassert(bool cond, char const * name, const char* f, size_t
     the doc in MatchEvaluator section.").c_str(), f, line);
 }
 
-static inline std::string _tostdstring(unsigned x){
+static inline std::string _tostdstring(size_t x){
+
+#ifndef JPCRE2_USE_MINIMUM_CXX_11
     char buf[128];
     int written = std::sprintf(buf, "%u", x);
     return (written > 0) ? std::string(buf, buf + written) : std::string();
+#else
+    return std::to_string(x);
+#endif
 }
 
 
@@ -1590,7 +1595,7 @@ struct select{
         ///@return Last error message
         virtual String getErrorMessage() const  {
             #ifdef JPCRE2_USE_MINIMUM_CXX_11
-            return select<Char, Map>::getErrorMessage(error_number, error_offset);
+            return select<Char, Map>::getErrorMessage(error_number, (int)error_offset);
             #else
             return select<Char>::getErrorMessage(error_number, error_offset);
             #endif


### PR DESCRIPTION
This pull request simply mutes a handful of warnings that Visual Studio raises during compilation on 64-bit.

* The warning about `_tostdstring` using `sprintf`. Workaround is for C++11 and up compilers to just used `std::to_string`
* The warning generated by the assert macros passing 64-bit size_t into 32-bit `_tostdstring`
* The warning about the implicit cast from size_t to int in `getErrorMessage()`. Just do an explicit cast