### PR TITLE
Address compiler warnings issued by Visual Studio

### DIFF
--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -198,10 +198,14 @@ static inline void _jvassert(bool cond, char const * name, const char* f, size_t
     the doc in MatchEvaluator section.").c_str(), f, line);
 }
 
-static inline std::string _tostdstring(unsigned x){
+static inline std::string _tostdstring(size_t x){
+#ifndef JPCRE2_USE_MINIMUM_CXX_11
     char buf[128];
-    int written = std::sprintf(buf, "%u", x);
+    int written = std::sprintf(buf, "%ull", (unsigned long long)x);
     return (written > 0) ? std::string(buf, buf + written) : std::string();
+#else
+    return std::to_string(x);
+#endif
 }
 
 
@@ -1355,7 +1359,7 @@ struct select{
         } else if(err_num == (int)ERROR::INSUFFICIENT_OVECTOR){
             return MSG<Char>::INSUFFICIENT_OVECTOR();
         } else if(err_num != 0) {
-            return getPcre2ErrorMessage((int) err_num);
+            return getPcre2ErrorMessage(err_num);
         } else return String();
     }
 
@@ -1590,7 +1594,7 @@ struct select{
         ///@return Last error message
         virtual String getErrorMessage() const  {
             #ifdef JPCRE2_USE_MINIMUM_CXX_11
-            return select<Char, Map>::getErrorMessage(error_number, error_offset);
+            return select<Char, Map>::getErrorMessage(error_number, (int)error_offset);
             #else
             return select<Char>::getErrorMessage(error_number, error_offset);
             #endif
@@ -3095,7 +3099,7 @@ struct select{
         ///@return Last error message
         String getErrorMessage() const  {
             #ifdef JPCRE2_USE_MINIMUM_CXX_11
-            return select<Char, Map>::getErrorMessage(error_number, error_offset);
+            return select<Char, Map>::getErrorMessage(error_number, (int)error_offset);
             #else
             return select<Char>::getErrorMessage(error_number, error_offset);
             #endif
@@ -3968,7 +3972,7 @@ struct select{
         ///@return Last error message
         String getErrorMessage() const  {
             #ifdef JPCRE2_USE_MINIMUM_CXX_11
-            return select<Char, Map>::getErrorMessage(error_number, error_offset);
+            return select<Char, Map>::getErrorMessage(error_number, (int)error_offset);
             #else
             return select<Char>::getErrorMessage(error_number, error_offset);
             #endif

--- a/src/jpcre2.hpp
+++ b/src/jpcre2.hpp
@@ -201,7 +201,7 @@ static inline void _jvassert(bool cond, char const * name, const char* f, size_t
 static inline std::string _tostdstring(size_t x){
 #ifndef JPCRE2_USE_MINIMUM_CXX_11
     char buf[128];
-    int written = std::sprintf(buf, "%ull", (unsigned long long)x);
+    int written = std::sprintf(buf, "%llu", (unsigned long long)x);
     return (written > 0) ? std::string(buf, buf + written) : std::string();
 #else
     return std::to_string(x);


### PR DESCRIPTION
### Address compiler warnings issued by Visual Studio

Visual Studio 2022 (and probably earlier versions) issues a compile error and series of warnings.

* `error C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS.`

* `warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data`

The sprintf compiler error is a result of invoking the classic C function, `sprintf`, in the `_tostdstring` function. The simple fix is to just fallback to `std::to_string` when C++ 11 or later is available. There may be legacys versions of Visual Studio that introduced the CRT error, but aren't C++11 aware.  For that small subsets, developers can use the available macro to disable that warning.  I did notice the code has its own `toString` set of helpers, but my assumption is that was for backwards compat with pre C++11 tools as well.

The conversion warnings are mainly on 64-bit. It's simply warning that the parameter being passed into `_tostdstring` by the `JPCRE2_ASSERT` macros invoked by `toOption` and `fromOption` is a 64-bit `size_t` getting implicitly casted to 32-bit unsigned int.  The simple workaround is to just allow `_tostdstring` to take an input parameter of type size_t.  But since size_t can be 32-bit or 64-bit, that would impact the safety of the original sprintf call for non c++11 compilers.  The format specifier should be `%z` for size_t, but Visual Studio doesn't support that.  The more universal solution I found was to just have `%ull` (unsigned long long) and just cast the x parameter explicitly.

There's some similar cast warnings on the `getErrorMessage` calls. Given what getErrorMessage does with the offset parameter, I didn't see any reason why the explicit (int) cast wouldn't work.
